### PR TITLE
mv the compilation process of 'awq kernels' into the Makefile and adapt it for docker build

### DIFF
--- a/server/Makefile-awq
+++ b/server/Makefile-awq
@@ -1,0 +1,12 @@
+awq_commit := f084f40bd996f3cf3a0633c1ad7d9d476c318aaa
+
+awq:
+	git clone https://github.com/mit-han-lab/llm-awq
+
+build-awq: awq
+	cd llm-awq && git fetch && git checkout $(awq_commit)
+	cd llm-awq/awq/kernels && python setup.py build
+
+install-awq: build-awq
+	pip uninstall awq -y || true
+	cd llm-awq && pip install -e . 

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -73,5 +73,3 @@ win32-setctime==1.1.0 ; python_version >= "3.9" and python_version < "3.13" and 
 wrapt==1.15.0 ; python_version >= "3.9" and python_version < "3.13"
 xxhash==3.3.0 ; python_version >= "3.9" and python_version < "3.13"
 yarl==1.9.2 ; python_version >= "3.9" and python_version < "3.13"
-# Custom 4-bit GEMM AWQ kernels
-git+https://github.com/mit-han-lab/llm-awq.git@f084f40bd996f3cf3a0633c1ad7d9d476c318aaa#subdirectory=awq/kernels


### PR DESCRIPTION
Thanks alot for your submission regarding the awq code. 

Based on your code, I encountered some missing compilation dependencies when building the image on the A10 machine. 
Following the compilation approach provided by TGI, I added a new 'awq-builder' to specifically handle the build for awq kernels. 

Fortunately, I succeeded, and below is the log of my successful run.

```bash
2023-09-21T10:25:31.695830Z  INFO text_generation_launcher: Args { model_id: "/data/LLAMA2/meta-llama-Llama-2-7b-chat-hf-w4-g128-awq", revision: None, validation_workers: 2, sharded: None, num_shard: None, quantize: Some(Awq), dtype: None, trust_remote_code: false, max_concurrent_requests: 128, max_best_of: 2, max_stop_sequences: 4, max_top_n_tokens: 5, max_input_length: 1024, max_total_tokens: 2048, waiting_served_ratio: 1.2, max_batch_prefill_tokens: 4096, max_batch_total_tokens: None, max_waiting_tokens: 20, hostname: "llama2-awq-00001-deployment-79bd75ccb5-k7wwn", port: 8080, shard_uds_path: "/tmp/text-generation-server", master_addr: "localhost", master_port: 29500, huggingface_hub_cache: Some("/data"), weights_cache_override: None, disable_custom_kernels: false, cuda_memory_fraction: 1.0, rope_scaling: None, rope_factor: None, json_output: false, otlp_endpoint: None, cors_allow_origin: [], watermark_gamma: None, watermark_delta: None, ngrok: false, ngrok_authtoken: None, ngrok_edge: None, env: false }
2023-09-21T10:25:31.695893Z  INFO text_generation_launcher: Sharding model on 2 processes
2023-09-21T10:25:31.696029Z  INFO download: text_generation_launcher: Starting download process.
2023-09-21T10:25:35.287816Z  INFO text_generation_launcher: Files are already present on the host. Skipping download.

2023-09-21T10:25:35.831819Z  INFO download: text_generation_launcher: Successfully downloaded weights.
2023-09-21T10:25:35.832374Z  INFO shard-manager: text_generation_launcher: Starting shard rank=0
2023-09-21T10:25:35.832486Z  INFO shard-manager: text_generation_launcher: Starting shard rank=1
2023-09-21T10:25:45.928498Z  INFO shard-manager: text_generation_launcher: Waiting for shard to be ready... rank=1
2023-09-21T10:25:45.928566Z  INFO shard-manager: text_generation_launcher: Waiting for shard to be ready... rank=0
2023-09-21T10:25:55.928667Z  INFO shard-manager: text_generation_launcher: Waiting for shard to be ready... rank=1
2023-09-21T10:25:56.028885Z  INFO shard-manager: text_generation_launcher: Waiting for shard to be ready... rank=0
2023-09-21T10:26:05.929100Z  INFO shard-manager: text_generation_launcher: Waiting for shard to be ready... rank=1
2023-09-21T10:26:06.029108Z  INFO shard-manager: text_generation_launcher: Waiting for shard to be ready... rank=0
2023-09-21T10:26:16.029174Z  INFO shard-manager: text_generation_launcher: Waiting for shard to be ready... rank=1
2023-09-21T10:26:16.128754Z  INFO shard-manager: text_generation_launcher: Waiting for shard to be ready... rank=0
2023-09-21T10:26:26.129356Z  INFO shard-manager: text_generation_launcher: Waiting for shard to be ready... rank=1
2023-09-21T10:26:26.228726Z  INFO shard-manager: text_generation_launcher: Waiting for shard to be ready... rank=0
2023-09-21T10:26:36.229136Z  INFO shard-manager: text_generation_launcher: Waiting for shard to be ready... rank=1
2023-09-21T10:26:36.229151Z  INFO shard-manager: text_generation_launcher: Waiting for shard to be ready... rank=0
2023-09-21T10:26:46.328494Z  INFO shard-manager: text_generation_launcher: Waiting for shard to be ready... rank=0
2023-09-21T10:26:46.329225Z  INFO shard-manager: text_generation_launcher: Waiting for shard to be ready... rank=1
2023-09-21T10:26:56.329531Z  INFO shard-manager: text_generation_launcher: Waiting for shard to be ready... rank=1
2023-09-21T10:26:56.428586Z  INFO shard-manager: text_generation_launcher: Waiting for shard to be ready... rank=0
2023-09-21T10:27:06.528278Z  INFO shard-manager: text_generation_launcher: Waiting for shard to be ready... rank=0
2023-09-21T10:27:06.528348Z  INFO shard-manager: text_generation_launcher: Waiting for shard to be ready... rank=1
2023-09-21T10:27:16.528788Z  INFO shard-manager: text_generation_launcher: Waiting for shard to be ready... rank=1
2023-09-21T10:27:16.628174Z  INFO shard-manager: text_generation_launcher: Waiting for shard to be ready... rank=0
2023-09-21T10:27:26.529401Z  INFO shard-manager: text_generation_launcher: Waiting for shard to be ready... rank=1
2023-09-21T10:27:26.628538Z  INFO shard-manager: text_generation_launcher: Waiting for shard to be ready... rank=0
2023-09-21T10:27:36.540698Z  INFO shard-manager: text_generation_launcher: Waiting for shard to be ready... rank=1
2023-09-21T10:27:36.728483Z  INFO shard-manager: text_generation_launcher: Waiting for shard to be ready... rank=0
2023-09-21T10:27:46.628749Z  INFO shard-manager: text_generation_launcher: Waiting for shard to be ready... rank=1
2023-09-21T10:27:46.728881Z  INFO shard-manager: text_generation_launcher: Waiting for shard to be ready... rank=0
2023-09-21T10:27:56.728880Z  INFO shard-manager: text_generation_launcher: Waiting for shard to be ready... rank=1
2023-09-21T10:27:56.729162Z  INFO shard-manager: text_generation_launcher: Waiting for shard to be ready... rank=0
2023-09-21T10:28:05.571114Z  INFO text_generation_launcher: Server started at unix:///tmp/text-generation-server-1

2023-09-21T10:28:05.583172Z  INFO text_generation_launcher: Server started at unix:///tmp/text-generation-server-0

2023-09-21T10:28:05.628872Z  INFO shard-manager: text_generation_launcher: Shard ready in 149.794117884s rank=1
2023-09-21T10:28:05.629618Z  INFO shard-manager: text_generation_launcher: Shard ready in 149.795428391s rank=0
2023-09-21T10:28:05.728924Z  INFO text_generation_launcher: Starting Webserver
2023-09-21T10:28:05.814872Z  WARN text_generation_router: router/src/main.rs:194: no pipeline tag found for model /data/LLAMA2/meta-llama-Llama-2-7b-chat-hf-w4-g128-awq
2023-09-21T10:28:05.825970Z  INFO text_generation_router: router/src/main.rs:213: Warming up model
2023-09-21T10:28:08.728783Z  INFO text_generation_router: router/src/main.rs:246: Setting max batch total tokens to 133088
2023-09-21T10:28:08.728844Z  INFO text_generation_router: router/src/main.rs:247: Connected
2023-09-21T10:28:08.728871Z  WARN text_generation_router: router/src/main.rs:252: Invalid hostname, defaulting to 0.0.0.0
```